### PR TITLE
Implement experimental `:match-conclusion` for rules

### DIFF
--- a/src/attr.cpp
+++ b/src/attr.cpp
@@ -13,6 +13,10 @@ std::ostream& operator<<(std::ostream& o, Attr a)
     case Attr::SYNTAX: o << "SYNTAX"; break;
     case Attr::REQUIRES: o << "REQUIRES"; break;
     case Attr::PREMISE_LIST: o << "PREMISE_LIST"; break;
+    case Attr::MATCH_CONCLUSION: o << "MATCH_CONCLUSION"; break;
+    case Attr::PREMISE_LIST_MATCH_CONCLUSION:
+      o << "PREMISE_LIST_MATCH_CONCLUSION";
+      break;
     case Attr::PROGRAM: o << "PROGRAM"; break;
     case Attr::ORACLE: o << "ORACLE"; break;
     case Attr::RIGHT_ASSOC: o << "RIGHT_ASSOC"; break;

--- a/src/attr.h
+++ b/src/attr.h
@@ -11,7 +11,7 @@ namespace alfc {
 enum class Attr
 {
   NONE = 0,
-  
+
   VAR,
   IMPLICIT,
   REQUIRES,
@@ -21,9 +21,11 @@ enum class Attr
   SYNTAX,
   PROGRAM,
   ORACLE,
-  
+
   // indicate how to construct proof rule steps
   PREMISE_LIST,
+  MATCH_CONCLUSION,
+  PREMISE_LIST_MATCH_CONCLUSION,  // It is possible to have both
 
   // indicate how to construct apps of function symbols
   RIGHT_ASSOC,
@@ -37,7 +39,7 @@ enum class Attr
   DATATYPE,
   DATATYPE_CONSTRUCTOR,
   CODATATYPE,
-  
+
   // internal
   CLOSURE
 };

--- a/src/expr_parser.cpp
+++ b/src/expr_parser.cpp
@@ -1197,6 +1197,7 @@ bool ExprParser::processAttributeMap(const AttrMap& attrs, Attr& ck, Expr& cons)
         case Attr::LIST:
         case Attr::SYNTAX:
         case Attr::PREMISE_LIST:
+        case Attr::PREMISE_LIST_MATCH_CONCLUSION:
         case Attr::LEFT_ASSOC:
         case Attr::RIGHT_ASSOC:
         case Attr::LEFT_ASSOC_NIL:

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1032,12 +1032,22 @@ Expr State::getProofRule(const std::string& name) const
   return d_null;
 }
 
+bool State::matchesConclusion(const ExprValue* rule)
+{
+  AppInfo* ainfo = getAppInfo(rule);
+  return (ainfo != nullptr
+          && (ainfo->d_attrCons == Attr::MATCH_CONCLUSION
+              || ainfo->d_attrCons == Attr::PREMISE_LIST_MATCH_CONCLUSION));
+}
+
 bool State::getActualPremises(const ExprValue* rule,
                               std::vector<Expr>& given,
                               std::vector<Expr>& actual)
 {
   AppInfo* ainfo = getAppInfo(rule);
-  if (ainfo!=nullptr && ainfo->d_attrCons==Attr::PREMISE_LIST)
+  if (ainfo != nullptr
+      && (ainfo->d_attrCons == Attr::PREMISE_LIST
+          || ainfo->d_attrCons == Attr::PREMISE_LIST_MATCH_CONCLUSION))
   {
     Expr plCons = ainfo->d_attrConsTerm;
     if (!plCons.isNull())

--- a/src/state.h
+++ b/src/state.h
@@ -121,6 +121,8 @@ class State
   Expr getVar(const std::string& name) const;
   /** Get the proof rule with the given name or nullptr if it does not exist */
   Expr getProofRule(const std::string& name) const;
+  /** Returns true if e is a rule that matches on the conclusion */
+  bool matchesConclusion(const ExprValue* rule);
   /** Get actual premises */
   bool getActualPremises(const ExprValue* ev,
                          std::vector<Expr>& given,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ set(alfc_test_file_list
     nat-type.smt3
     use-match.smt3
     match-simple.smt3
+    match_conclusion.smt3
     and-intro-old.smt3
     strings-rules-test.smt3
     ite-compile-test.smt3

--- a/tests/match_conclusion.smt3
+++ b/tests/match_conclusion.smt3
@@ -1,0 +1,12 @@
+(include "Builtin-theory.smt3")
+
+(declare-rule match1 ((F1 Bool) (F2 Bool))
+    :match-conclusion (and F1 F2)
+)
+
+(declare-const c1 Bool)
+(declare-const c2 Bool)
+(step test1 (and c1 c2) :rule match1)
+
+; This fails as expected:
+; (step test2 :rule match1)


### PR DESCRIPTION
This adds a keyword to `define-rule` that makes the conclusion the first argument of a rule, and introduces `step` to make a given conclusion the first argument, or fail if no conclusion is given.
```clojure
(declare-rule match1 ((F1 Bool) (F2 Bool))
    :match-conclusion (and F1 F2)
)

(declare-const c1 Bool)
(declare-const c2 Bool)
(step test1 (and c1 c2) :rule match1)

; This fails
(step test2 :rule match1)
```
The proof term `test1` is just `(match1 (and c1 c2))`.

### Justification

After some experiments with Alethe Classic rules, I am changing my opinion about needing a feature to capture explicitly given conclusions.

For example, the simple `not_not` rule for double-negation elimination.  It introduces the clause `(not (not (not T)))`, `T`.  You would like to write this as a proof rule that takes `T` as an argument.  However, in Alethe Classic the solver is free to choose the order of the literals in the conclusion.  Hence, a rule with `:conclusion (cl (not (not (not T))) (not T))` could fail if the solver prints the conclusion in the wrong order.
Therefore, any Alethe Classic rule that does not generate a unit clause would need the entire conclusion as an argument.

Whit this change the rule becomes:
```clojure
(program check_not_not ((phi Bool))
    (Bool) Bool
    (
    ((check_not_not (cl (not (not (not phi))) phi)) true)
    ((check_not_not (cl phi (not (not (not phi))))) true)
    )
)
(declare-rule not_not ((CL Bool))
  :requires ((check_not_not CL) true)
  :match-conclusion CL
)
```
Still not perfect, but better.

### Implementation

When defining a rule, one can use `:match-conclusion` instead of `:conclusion`.  If this is used, the conclusion must be given in the step.  To achieve this, define-rule with a `:match-conclusion T` adds an additional argument `Quote T` to the start of the argument list, and sets the conclusion to `Proof T`.  The `step` command detects rules annotated with `:match-conclusion` and hands the conclusion to the rule as the first argument.

Hence, this feature doesn't change functional semantic of rules, it is just syntactic sugar for `step`.

**TODO**: support in compiled version and write docu.