### PR TITLE
Update syntax for list operators

### DIFF
--- a/src/kind.cpp
+++ b/src/kind.cpp
@@ -209,6 +209,10 @@ bool isLiteralOp(Kind k)
     // lists
     case Kind::EVAL_NIL:
     case Kind::EVAL_CONS:
+    case Kind::EVAL_LIST_LENGTH:
+    case Kind::EVAL_LIST_CONCAT:
+    case Kind::EVAL_LIST_NTH:
+    case Kind::EVAL_LIST_FIND:
     // boolean
     case Kind::EVAL_NOT:
     case Kind::EVAL_AND:
@@ -242,9 +246,10 @@ bool isListLiteralOp(Kind k)
   {
     case Kind::EVAL_NIL:
     case Kind::EVAL_CONS:
-    case Kind::EVAL_CONCAT:
-    case Kind::EVAL_EXTRACT:
-    case Kind::EVAL_FIND:
+    case Kind::EVAL_LIST_LENGTH:
+    case Kind::EVAL_LIST_CONCAT:
+    case Kind::EVAL_LIST_NTH:
+    case Kind::EVAL_LIST_FIND:
       return true;
     default:
       break;

--- a/src/kind.cpp
+++ b/src/kind.cpp
@@ -58,6 +58,10 @@ std::ostream& operator<<(std::ostream& o, Kind k)
     // lists
     case Kind::EVAL_NIL: o << "EVAL_NIL";break;
     case Kind::EVAL_CONS: o << "EVAL_CONS"; break;
+    case Kind::EVAL_LIST_LENGTH: o << "EVAL_LIST_LENGTH"; break;
+    case Kind::EVAL_LIST_CONCAT: o << "EVAL_LIST_CONCAT"; break;
+    case Kind::EVAL_LIST_NTH: o << "EVAL_LIST_NTH"; break;
+    case Kind::EVAL_LIST_FIND: o << "EVAL_LIST_FIND"; break;
     // boolean
     case Kind::EVAL_NOT: o << "EVAL_NOT"; break;
     case Kind::EVAL_AND: o << "EVAL_AND"; break;
@@ -123,6 +127,10 @@ std::string kindToTerm(Kind k)
         // lists
         case Kind::EVAL_NIL: ss << "nil"; break;
         case Kind::EVAL_CONS: ss << "cons"; break;
+        case Kind::EVAL_LIST_LENGTH: ss << "list_len"; break;
+        case Kind::EVAL_LIST_CONCAT: ss << "list_concat"; break;
+        case Kind::EVAL_LIST_NTH: ss << "list_nth"; break;
+        case Kind::EVAL_LIST_FIND: ss << "list_find"; break;
         // boolean
         case Kind::EVAL_NOT: ss << "not"; break;
         case Kind::EVAL_AND: ss << "and"; break;

--- a/src/kind.h
+++ b/src/kind.h
@@ -68,6 +68,10 @@ enum class Kind
   // lists
   EVAL_NIL,
   EVAL_CONS,
+  EVAL_LIST_LENGTH,
+  EVAL_LIST_CONCAT,
+  EVAL_LIST_NTH,
+  EVAL_LIST_FIND,
   // boolean
   EVAL_NOT,
   EVAL_AND,

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -59,6 +59,10 @@ State::State(Options& opts, Stats& stats)
   // lists
   bindBuiltinEval("nil", Kind::EVAL_NIL);
   bindBuiltinEval("cons", Kind::EVAL_CONS);
+  bindBuiltinEval("list_len", Kind::EVAL_LIST_LENGTH);
+  bindBuiltinEval("list_concat", Kind::EVAL_LIST_CONCAT);
+  bindBuiltinEval("list_nth", Kind::EVAL_LIST_NTH);
+  bindBuiltinEval("list_find", Kind::EVAL_LIST_FIND);
   // boolean
   bindBuiltinEval("not", Kind::EVAL_NOT);
   bindBuiltinEval("and", Kind::EVAL_AND);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -816,18 +816,7 @@ Expr State::mkExpr(Kind k, const std::vector<Expr>& children)
   else if (isLiteralOp(k))
   {
     // only if correct arity, else we will catch the type error
-    bool isArityOk = false;
-    if (TypeChecker::checkArity(k, vchildren.size()))
-    {
-      isArityOk = true;
-    }
-    else if (TypeChecker::checkArity(k, vchildren.size()-1))
-    {
-      // handles the case where the operator is "indexed" by a function
-      Expr cc1 = children[0];
-      Expr tc1 = d_tc.getType(cc1);
-      isArityOk = (tc1.getKind()==Kind::FUNCTION_TYPE);
-    }
+    bool isArityOk = TypeChecker::checkArity(k, vchildren.size());
     if (isArityOk)
     {
       // return the evaluation

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -656,10 +656,10 @@ Expr State::mkExpr(Kind k, const std::vector<Expr>& children)
             {
               cc[prevIndex] = curr;
               cc[nextIndex] = vchildren[isLeft ? i : nchild - i];
-              // if the "head" child is marked as list, we construct Kind::EVAL_CONCAT
+              // if the "head" child is marked as list, we construct Kind::EVAL_LIST_CONCAT
               if (isNil && getConstructorKind(cc[nextIndex]) == Attr::LIST)
               {
-                curr = mkExprInternal(Kind::EVAL_CONCAT, cc);
+                curr = mkExprInternal(Kind::EVAL_LIST_CONCAT, cc);
               }
               else
               {

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -144,7 +144,6 @@ bool TypeChecker::checkArity(Kind k, size_t nargs, std::ostream* out)
     case Kind::EVAL_RAT_DIV:
     case Kind::EVAL_TO_BIN:
     case Kind::EVAL_FIND:
-    case Kind::EVAL_CONS:
     case Kind::EVAL_LIST_LENGTH:
       ret = (nargs==2);
       break;
@@ -177,6 +176,7 @@ bool TypeChecker::checkArity(Kind k, size_t nargs, std::ostream* out)
       break;
     case Kind::EVAL_REQUIRES:
     case Kind::EVAL_IF_THEN_ELSE:
+    case Kind::EVAL_CONS:
     case Kind::EVAL_LIST_NTH:
       ret = (nargs==3);
       break;

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -130,7 +130,6 @@ Expr TypeChecker::getType(Expr& e, std::ostream* out)
 
 bool TypeChecker::checkArity(Kind k, size_t nargs, std::ostream* out)
 {
-  // Note this is the arity after the list operator for alf.cons, alf.find, and so on.
   bool ret = false;
   // check arities
   switch(k)
@@ -146,6 +145,7 @@ bool TypeChecker::checkArity(Kind k, size_t nargs, std::ostream* out)
     case Kind::EVAL_TO_BIN:
     case Kind::EVAL_FIND:
     case Kind::EVAL_CONS:
+    case Kind::EVAL_LIST_LENGTH:
       ret = (nargs==2);
       break;
     case Kind::EVAL_ADD:
@@ -155,6 +155,9 @@ bool TypeChecker::checkArity(Kind k, size_t nargs, std::ostream* out)
     case Kind::EVAL_XOR:
     case Kind::EVAL_CONCAT:
       ret = (nargs>=2);
+      break;
+    case Kind::EVAL_LIST_CONCAT:
+      ret = (nargs>=3);
       break;
     case Kind::PROOF_TYPE:
     case Kind::EVAL_TYPE_OF:
@@ -174,6 +177,7 @@ bool TypeChecker::checkArity(Kind k, size_t nargs, std::ostream* out)
       break;
     case Kind::EVAL_REQUIRES:
     case Kind::EVAL_IF_THEN_ELSE:
+    case Kind::EVAL_LIST_NTH:
       ret = (nargs==3);
       break;
     case Kind::EVAL_EXTRACT:
@@ -1217,7 +1221,7 @@ Expr TypeChecker::evaluateLiteralOpInternal(
     }
     break;
     case Kind::EVAL_CONS:
-    case Kind::EVAL_CONCAT:
+    case Kind::EVAL_LIST_CONCAT:
     {
       std::vector<ExprValue*> targs;
       ExprValue* b = getNAryChildren(args[tailIndex], op, nil, targs, isLeft);
@@ -1246,7 +1250,19 @@ Expr TypeChecker::evaluateLiteralOpInternal(
       ret = args[tailIndex];
     }
       break;
-    case Kind::EVAL_EXTRACT:
+    case Kind::EVAL_LIST_LENGTH:
+    {
+      ExprValue* a = getNAryChildren(args[1], op, nil, hargs, isLeft);
+      if (a==nullptr)
+      {
+        Trace("type_checker") << "...head not in list form" << std::endl;
+        return d_null;
+      }
+      Literal lret = Literal(Integer(hargs.size()));
+      return Expr(d_state.mkLiteralInternal(lret));
+    }
+      break;
+    case Kind::EVAL_LIST_NTH:
     {
       // (alf.extract <op> <term> <n>) returns the n^th child of <op>-application <term>
       if (args[2]->getKind()!=Kind::NUMERAL)
@@ -1268,7 +1284,7 @@ Expr TypeChecker::evaluateLiteralOpInternal(
       return d_null;
     }
       break;
-    case Kind::EVAL_FIND:
+    case Kind::EVAL_LIST_FIND:
     {
       getNAryChildren(args[1], op, nil, hargs, isLeft);
       std::vector<ExprValue*>::iterator it = std::find(hargs.begin(), hargs.end(), args[2]);
@@ -1310,14 +1326,7 @@ ExprValue* TypeChecker::getLiteralOpType(Kind k,
                                          std::vector<ExprValue*>& childTypes,
                                          std::ostream* out)
 {
-  // operators with functions at the first index are "indexed"
-  size_t i = 0;
-  if (!childTypes.empty() && childTypes[0]->getKind()==Kind::FUNCTION_TYPE)
-  {
-    // TODO: ensure the function is binary with same types
-    i++;
-  }
-  if (!checkArity(k, childTypes.size()-i, out))
+  if (!checkArity(k, childTypes.size(), out))
   {
     return d_null.getValue();
   }
@@ -1349,10 +1358,13 @@ ExprValue* TypeChecker::getLiteralOpType(Kind k,
       return childTypes[1];
     case Kind::EVAL_REQUIRES:
       return childTypes[2];
+    case Kind::EVAL_LIST_CONCAT:
+    case Kind::EVAL_LIST_NTH:
+      return childTypes[1];
     case Kind::EVAL_CONCAT:
     case Kind::EVAL_EXTRACT:
-      // type is the first child, maybe after a function
-      return childTypes[i];
+      // type is the first child
+      return childTypes[0];
     case Kind::EVAL_IS_EQ:
     case Kind::EVAL_IS_NEG:
       return d_state.mkBoolType().getValue();
@@ -1362,6 +1374,8 @@ ExprValue* TypeChecker::getLiteralOpType(Kind k,
     case Kind::EVAL_TO_INT:
     case Kind::EVAL_LENGTH:
     case Kind::EVAL_FIND:
+    case Kind::EVAL_LIST_LENGTH:
+    case Kind::EVAL_LIST_FIND:
       return getOrSetLiteralTypeRule(Kind::NUMERAL);
     case Kind::EVAL_RAT_DIV:
     case Kind::EVAL_TO_RAT:

--- a/tests/Booleans-rules.smt3
+++ b/tests/Booleans-rules.smt3
@@ -138,7 +138,7 @@
 (declare-rule and_elim ((Fs Bool) (i Int))
     :premises (Fs)
     :args (i)
-    :conclusion (alf.list_extract and Fs i)
+    :conclusion (alf.list_nth and Fs i)
 )
 
 ; AND_INTRO
@@ -151,7 +151,7 @@
 (declare-rule not_or_elim ((Fs Bool) (i Int))
     :premises ((not Fs))
     :args (i)
-    :conclusion (not (alf.list_extract or Fs i))
+    :conclusion (not (alf.list_nth or Fs i))
 )
 
 ; IMPLIES_ELIM
@@ -265,7 +265,7 @@
 ; CNF_AND_POS
 (declare-rule cnf_and_pos ((Fs Bool) (i Int))
     :args (Fs i)
-    :conclusion (or (not Fs) (alf.list_extract and Fs i))
+    :conclusion (or (not Fs) (alf.list_nth and Fs i))
 )
 
 ; CNF_AND_NEG
@@ -283,7 +283,7 @@
 ; CNF_OR_NEG
 (declare-rule cnf_or_neg ((Fs Bool) (i Int))
     :args (Fs i)
-    :conclusion (or Fs (not (alf.list_extract or Fs i)))
+    :conclusion (or Fs (not (alf.list_nth or Fs i)))
 )
 
 ; CNF_IMPLIES_POS

--- a/tests/Booleans-rules.smt3
+++ b/tests/Booleans-rules.smt3
@@ -41,7 +41,7 @@
       ((resolve C1 C2 pol L)
         (let ((lp (alf.ite pol L (not L))))
         (let ((ln (alf.ite pol (not L) L)))
-            (from_clause (alf.concat or
+            (from_clause (alf.list_concat or
                     (removeSelf lp (to_clause C1))
                     (removeSelf ln (to_clause C2)))))))
     )
@@ -63,7 +63,7 @@
             (chainResolveRec
                 (let ((lp (alf.ite pol L (not L))))
                 (let ((ln (alf.ite pol (not L) L)))
-                    (alf.concat or
+                    (alf.list_concat or
                             (removeSelf lp C1)
                             (removeSelf ln (to_clause C2))))) Cs args))
     )
@@ -89,7 +89,7 @@
 (program factorLiterals ((xs Bool :list) (l Bool) (ls Bool :list))
     (Bool Bool) Bool
     (
-        ((factorLiterals xs (or l ls)) (let ((cond (alf.is_neg (alf.find or xs l))))
+        ((factorLiterals xs (or l ls)) (let ((cond (alf.is_neg (alf.list_find or xs l))))
                                        (let ((ret (factorLiterals
                                                     (alf.ite cond (alf.cons or l xs) xs)
                                                     ls)))
@@ -138,7 +138,7 @@
 (declare-rule and_elim ((Fs Bool) (i Int))
     :premises (Fs)
     :args (i)
-    :conclusion (alf.extract and Fs i)
+    :conclusion (alf.list_extract and Fs i)
 )
 
 ; AND_INTRO
@@ -151,7 +151,7 @@
 (declare-rule not_or_elim ((Fs Bool) (i Int))
     :premises ((not Fs))
     :args (i)
-    :conclusion (not (alf.extract or Fs i))
+    :conclusion (not (alf.list_extract or Fs i))
 )
 
 ; IMPLIES_ELIM
@@ -265,7 +265,7 @@
 ; CNF_AND_POS
 (declare-rule cnf_and_pos ((Fs Bool) (i Int))
     :args (Fs i)
-    :conclusion (or (not Fs) (alf.extract and Fs i))
+    :conclusion (or (not Fs) (alf.list_extract and Fs i))
 )
 
 ; CNF_AND_NEG
@@ -283,7 +283,7 @@
 ; CNF_OR_NEG
 (declare-rule cnf_or_neg ((Fs Bool) (i Int))
     :args (Fs i)
-    :conclusion (or Fs (not (alf.extract or Fs i)))
+    :conclusion (or Fs (not (alf.list_extract or Fs i)))
 )
 
 ; CNF_IMPLIES_POS

--- a/tests/Sets-theory.smt3
+++ b/tests/Sets-theory.smt3
@@ -28,7 +28,7 @@
 
 (declare-const rel.tclosure (-> (! Type :var T :implicit) (Set (Tuple T T)) (Set (Tuple T T))))
 (declare-const rel.transpose (-> (! Type :var T :implicit) (Set T) (Set (nary.reverse Tuple UnitTuple T))))
-(declare-const rel.product (-> (! Type :var T :implicit) (! Type :var U :implicit) (Set T) (Set U) (Set (alf.concat Tuple T U))))
+(declare-const rel.product (-> (! Type :var T :implicit) (! Type :var U :implicit) (Set T) (Set U) (Set (alf.list_concat Tuple T U))))
 (declare-const rel.join (-> (! Type :var T :implicit) (! Type :var U :implicit) (Set T) (Set U) (Set (nary.join Tuple UnitTuple T U))))
 (declare-const rel.group (-> (! Type :var T :implicit) @List (Set T) (Set (Set T))))
 

--- a/tests/Strings-programs.smt3
+++ b/tests/Strings-programs.smt3
@@ -22,7 +22,7 @@
 (define $char_type_of ((T Type)) 
   (alf.match ((U Type)) T (((Seq U) U))))
 (define $str_concat ((T Type :implicit) (x (Seq T)) (y (Seq T)))
-  (alf.concat str.++ x y))
+  (alf.list_concat str.++ x y))
 (define $str_cons ((T Type :implicit) (x (Seq T)) (y (Seq T)))
   (alf.cons str.++ x y))
 

--- a/tests/examples-nary.smt3
+++ b/tests/examples-nary.smt3
@@ -39,7 +39,7 @@
 ; Concat
 (declare-rule check_concat((t1 S) (t2 S) (out S))
     :args (t1 t2 out)
-    :requires (((alf.concat cons t1 t2) out))
+    :requires (((alf.list_concat cons t1 t2) out))
     :conclusion true
 )
 

--- a/tests/or-concat-false.smt3
+++ b/tests/or-concat-false.smt3
@@ -6,7 +6,7 @@
 
 
 (declare-rule id ((B Bool)) :premises (B) :conclusion (alf.cons or false B))
-(declare-rule concatOr ((A Bool) (B Bool)) :premises (A B) :conclusion (alf.concat or A B))
+(declare-rule concatOr ((A Bool) (B Bool)) :premises (A B) :conclusion (alf.list_concat or A B))
 
 (step @p1 (or false) :rule id :premises (@p0))
 

--- a/tests/rare-example.smt3
+++ b/tests/rare-example.smt3
@@ -26,7 +26,7 @@
 )
 
 (declare-axiom bool-or-false ((xs Bool :list) (ys Bool :list))
-  (= (or xs false ys) (elim_singleton_list_rhs or (alf.concat or xs ys)))
+  (= (or xs false ys) (elim_singleton_list_rhs or (alf.list_concat or xs ys)))
 )
 
 (step @p0 (= (or a b true c) true) :rule bool-or-true :args ((or a b) (or c)))
@@ -38,7 +38,7 @@
 (step @p5 (= (or (or a b) false) (or a b)) :rule bool-or-false :args ((or (or a b)) false))
 
 (declare-axiom bool-and-true ((xs Bool :list) (ys Bool :list))
-  (= (and xs true ys) (elim_singleton_list_lhs and (alf.concat and xs ys)))
+  (= (and xs true ys) (elim_singleton_list_lhs and (alf.list_concat and xs ys)))
 )
 
 (declare-axiom bool-and-false ((xs Bool :list) (ys Bool :list))

--- a/user_manual.md
+++ b/user_manual.md
@@ -329,12 +329,12 @@ In other words, the definitions of `Paab` and `Qaab` are equivalent to the terms
 More generally, for an right-associative operator `f` with nil terminator `nil`,
 the term `(f t1 ... tn)` is de-sugared based on whether each `t1 ... tn` is marked with `:list`.
 - The nil terminator is inserted at the tail of the function application unless `tn` is marked as `:list`,
-- If `ti` is marked as `:list` where `1<=i<n`, then `ti` is prepended to the overall application using a concatentation operation `alf.concat`. The semantics of this operator is provided later in [list-computation](#list-computation).
+- If `ti` is marked as `:list` where `1<=i<n`, then `ti` is prepended to the overall application using a concatentation operation `alf.list_concat`. The semantics of this operator is provided later in [list-computation](#list-computation).
 
 In detail, the returned term from desugaring `(f t1 ... tn)` is constructed inductively.
 If `tn` is marked with `:list`, the returned term is initialized to `tn` and we process children `ti` from `i = n-1 ... 1`.
 If `tn` is not marked with `:list`, the return term is initialized to the nil terminator of `f` and we process children `ti` from `i = n .. 1`.
-For each term `ti` we process, the returned term `r` is updated to `(f ti r)` if `ti` is not marked with `:list`, or to `(alf.concat f ti r)`
+For each term `ti` we process, the returned term `r` is updated to `(f ti r)` if `ti` is not marked with `:list`, or to `(alf.list_concat f ti r)`
 if `ti` is marked with `:list`.
 Examples of this desugaring are given below.
 
@@ -344,10 +344,10 @@ Examples of this desugaring are given below.
     (and
         (or x y)        ; (or x (or y false))
         (or x z)        ; (or x z)
-        (or x z y)      ; (or x (alf.concat or z (or y false)))
+        (or x z y)      ; (or x (alf.list_concat or z (or y false)))
         (or x)          ; (or x false)
         (or z)          ; z
-        (or z y w x)    ; (alf.concat or z (or y (alf.concat w (or x false)))
+        (or z y w x)    ; (alf.list_concat or z (or y (alf.list_concat or w (or x false)))
     ))
 ```
 
@@ -674,11 +674,13 @@ List operators:
     - If `f` is a right associative operator, return its nil terminator.
 - `(alf.cons f t1 t2)`
     - If `t2` is an `f`-list, then this returns the term `(f t1 t2)`.
-- `(alf.concat f t1 t2)`
+- `(alf.list_len f t)`
+    - If `t` is an `f`-list with children `t1 ... tn`, then this returns `n`.
+- `(alf.list_concat f t1 t2)`
     - If `t1` is an `f`-list with children `t11 ... t1n` and `t2` is an `f`-list with children `t21 ... t2m`, this returns `(f t11 ... t1n t21 ... t2m)` if `n+m>0` and `nil` otherwise. Otherwise, this operator does not evaluate.
-- `(alf.extract f t1 t2)`
+- `(alf.list_nth f t1 t2)`
     - If `f` is a right associative operator with nil terminator with nil terminator `nil`, `t1` is `(f s0 ... s{n-1})`, and `t2` is a numeral value such that `0<=t2<n`, then this returns `s_{t2}`. Otherwise, this operator does not evaluate.
-- `(alf.find f t1 t2)`
+- `(alf.list_find f t1 t2)`
     - If `f` is a right associative operator with nil terminator with nil terminator `nil` and `t1` is `(f s0 ... s{n-1})`, then this returns the smallest numeral value `i` such that `t2` is syntactically equal to `si`, or `-1` if no such `si` can be found. Otherwise, this operator does not evaluate.
 
 ### List Computation Examples
@@ -704,24 +706,24 @@ The terms on both sides of the given evaluation are written in their form prior 
 (alf.cons and true (and a))         == (and a)
 (alf.cons and (and a) true)         == (and (and a))
 
-(alf.concat or false false)         == false
-(alf.concat or (or a b) (or b))     == (or a b b)
-(alf.concat or false (or b))        == (or b)
-(alf.concat or (or a b b) false)    == (or a b b)
-(alf.concat or a (or b))            == (alf.concat or a (or b))         ; since a is not an or-list
-(alf.concat or (or a) b)            == (alf.concat or (or a) b)         ; since b is not an or-list
-(alf.concat or (or a) (or b))       == (or a b)
-(alf.concat or (and a b) false)     == (alf.concat or (and a b) false)  ; since (and a b) is not an or-list
+(alf.list_concat or false false)         == false
+(alf.list_concat or (or a b) (or b))     == (or a b b)
+(alf.list_concat or false (or b))        == (or b)
+(alf.list_concat or (or a b b) false)    == (or a b b)
+(alf.list_concat or a (or b))            == (alf.list_concat or a (or b))         ; since a is not an or-list
+(alf.list_concat or (or a) b)            == (alf.list_concat or (or a) b)         ; since b is not an or-list
+(alf.list_concat or (or a) (or b))       == (or a b)
+(alf.list_concat or (and a b) false)     == (alf.list_concat or (and a b) false)  ; since (and a b) is not an or-list
 
-(alf.extract or (or a b a) 1)       == b
-(alf.extract or (or a) 0)           == a
-(alf.extract or false 0)            == (alf.extract or false 0)         ; since false has <=0 children
-(alf.extract or (or a b a) 3)       == (alf.extract or (or a b a) 3)    ; since (or a b a) has <=3 children
-(alf.extract or (and a b b) 0)      == (alf.extract or (and a b b) 0)   ; since (and a b b) is not an or-list
+(alf.list_nth or (or a b a) 1)           == b
+(alf.list_nth or (or a) 0)               == a
+(alf.list_nth or false 0)                == (alf.list_nth or false 0)         ; since false has <=0 children
+(alf.list_nth or (or a b a) 3)           == (alf.list_nth or (or a b a) 3)    ; since (or a b a) has <=3 children
+(alf.list_nth or (and a b b) 0)          == (alf.list_nth or (and a b b) 0)   ; since (and a b b) is not an or-list
 
-(alf.find or (or a b a) b)          == 1
-(alf.find or (or a b a) true)       == -1
-(alf.find or (and a b b) a)         == (alf.find or (and a b b) a)      ; since (and a b b) is not an or-list
+(alf.list_find or (or a b a) b)          == 1
+(alf.list_find or (or a b a) true)       == -1
+(alf.list_find or (and a b b) a)         == (alf.find or (and a b b) a)      ; since (and a b b) is not an or-list
 ```
 
 ### Nil terminator with additional arguments
@@ -816,7 +818,7 @@ In this example, the type of `bvor` is `(-> (! Int :var m :implicit) (BitVec m) 
 
 If a function `f` is given a nil terminator with free parameters, this impacts:
 - How applications of `f` are desugared, and
-- How list operations such as `alf.nil`, `alf.cons`, and `alf.concat` are computed for `f`.
+- How list operations such as `alf.nil`, `alf.cons`, and `alf.list_concat` are computed for `f`.
 
 For the former, say we apply `(f t1 ... tn)`, where `f` is right associative with nil terminator `nil`, where `nil` has free paramters `u1 ... um`.
 Similar to the procedure described in [assoc-nil](#assoc-nil), if `tn` is not marked with `:list`, we insert the nil terminator of `f` to the end of the argument list.
@@ -836,7 +838,7 @@ Examples of this are given in the following, assuming the declaration of `bvor` 
     (bvor x)          ; (bvor x #b0000)
     (bvor z w)        ; (bvor z (bvor w (alf.nil bvor z w)))
     (bvor z u)        ; (bvor z u)
-    (bvor u z)        ; (alf.concat bvor u (bvor z (alf.nil bvor u z)))
+    (bvor u z)        ; (alf.list_concat bvor u (bvor z (alf.nil bvor u z)))
     ...
 )
 ```
@@ -850,7 +852,7 @@ In the third, example, `(bvor z w)` is type checked to `(BitVec m)[n/m]`, where 
 Thus, we do not compute its nil terminator and instead construct the placeholder `(alf.nil bvor z w)`.
 This is then used as the nil terminator since `w` is not marked as `:list`.
 In the fourth example, `(bvor z u)` is also type checked to `(BitVec m)[n/m]`, but in this case the nil terminator is not used since `u` is marked as `:list`.
-In the fifth example, we use `alf.concat` as before since the list term `u` appears as the first argument.
+In the fifth example, we use `alf.list_concat` as before since the list term `u` appears as the first argument.
 Similar to the third example, a placeholder for the nil terminator is generated.
 
 Any list operation involving `f` first requires computing the nil terminator in question.
@@ -893,8 +895,8 @@ The following are examples of list operations when using parameterized constant 
 (alf.cons bvor c #b0000)            == (alf.cons bvor c #b0000) ; since (bvor c #b0000) is ill-typed
 (alf.cons bvor a (bvor a b))        == (bvor a a b)
 
-(alf.concat bvor #b0000 #b0000)       == #b0000
-(alf.concat bvor (bvor a b) (bvor b)) == (bvor a b b)
+(alf.list_concat bvor #b0000 #b0000)       == #b0000
+(alf.list_concat bvor (bvor a b) (bvor b)) == (bvor a b b)
 ```
 
 > If no free parameters are used in the nil terminator of a parameterized constant, then it is treated equivalent to if it were declared via an ordinary declare-const command, and a warning is issued.
@@ -1192,8 +1194,8 @@ However, `(contains (or a b c) a)` does not evaluate in this example.
 ```
 In this variant, both `xs` and `x` were marked with `:list`.
 The ALF checker will reject this definition since it implies that a computational operator appears in a pattern for matching.
-In particular, the term `(or x xs)` is equivalent to `(alf.concat or x xs)` after desugaring.
-Thus, the third case of the program, `(contains (alf.concat or x xs) l)`, is not a legal pattern.
+In particular, the term `(or x xs)` is equivalent to `(alf.list_concat or x xs)` after desugaring.
+Thus, the third case of the program, `(contains (alf.list_concat or x xs) l)`, is not a legal pattern.
 
 ### Example: Substitution
 

--- a/user_manual.md
+++ b/user_manual.md
@@ -706,14 +706,20 @@ The terms on both sides of the given evaluation are written in their form prior 
 (alf.cons and true (and a))         == (and a)
 (alf.cons and (and a) true)         == (and (and a))
 
-(alf.list_concat or false false)         == false
-(alf.list_concat or (or a b) (or b))     == (or a b b)
-(alf.list_concat or false (or b))        == (or b)
-(alf.list_concat or (or a b b) false)    == (or a b b)
-(alf.list_concat or a (or b))            == (alf.list_concat or a (or b))         ; since a is not an or-list
-(alf.list_concat or (or a) b)            == (alf.list_concat or (or a) b)         ; since b is not an or-list
-(alf.list_concat or (or a) (or b))       == (or a b)
-(alf.list_concat or (and a b) false)     == (alf.list_concat or (and a b) false)  ; since (and a b) is not an or-list
+(alf.list_len or (or a b))          == 2
+(alf.list_len or (or (or a a) b))   == 2
+(alf.list_len or false)             == 0
+(alf.list_len or (and a b))         == (alf.list_len or (and a b))  ; since (and a b) is not an or-list
+
+(alf.list_concat or false false)            == false
+(alf.list_concat or (or a b) (or b))        == (or a b b)
+(alf.list_concat or (or (or a a)) (or b))   == (or(or a a) b)
+(alf.list_concat or false (or b))           == (or b)
+(alf.list_concat or (or a b b) false)       == (or a b b)
+(alf.list_concat or a (or b))               == (alf.list_concat or a (or b))         ; since a is not an or-list
+(alf.list_concat or (or a) b)               == (alf.list_concat or (or a) b)         ; since b is not an or-list
+(alf.list_concat or (or a) (or b))          == (or a b)
+(alf.list_concat or (and a b) false)        == (alf.list_concat or (and a b) false)  ; since (and a b) is not an or-list
 
 (alf.list_nth or (or a b a) 1)           == b
 (alf.list_nth or (or a) 0)               == a

--- a/user_manual.md
+++ b/user_manual.md
@@ -713,7 +713,7 @@ The terms on both sides of the given evaluation are written in their form prior 
 
 (alf.list_concat or false false)            == false
 (alf.list_concat or (or a b) (or b))        == (or a b b)
-(alf.list_concat or (or (or a a)) (or b))   == (or(or a a) b)
+(alf.list_concat or (or (or a a)) (or b))   == (or (or a a) b)
 (alf.list_concat or false (or b))           == (or b)
 (alf.list_concat or (or a b b) false)       == (or a b b)
 (alf.list_concat or a (or b))               == (alf.list_concat or a (or b))         ; since a is not an or-list


### PR DESCRIPTION
The motivation is to disambiguate different arities for the overloaded operators, which simplifies parsing and type checking.