### PR TITLE
Make syntax for declare-rule and program extensible

### DIFF
--- a/src/cmd_parser.cpp
+++ b/src/cmd_parser.cpp
@@ -318,6 +318,14 @@ bool CmdParser::parseNextCommand()
       }
       d_state.pushScope();
       std::string name = d_eparser.parseSymbol();
+      if (d_lex.peekToken()==Token::KEYWORD)
+      {
+        std::string keyword = d_eparser.parseKeyword();
+        if (keyword!="alfc")
+        {
+          d_lex.parseError("Unsupported rule format");
+        }
+      }
       std::vector<Expr> vs =
           d_eparser.parseAndBindSortedVarList();
       Expr assume;
@@ -610,10 +618,18 @@ bool CmdParser::parseNextCommand()
       }
     }
     break;
-    // (program <symbol> (<sorted_var>*) (<sort>*) <sort> (<term_pair>+)?)
+    // (program <symbol> <keyword>? (<sorted_var>*) (<sort>*) <sort> (<term_pair>+)?)
     case Token::PROGRAM:
     {
       std::string name = d_eparser.parseSymbol();
+      if (d_lex.peekToken()==Token::KEYWORD)
+      {
+        std::string keyword = d_eparser.parseKeyword();
+        if (keyword!="alfc")
+        {
+          d_lex.parseError("Unsupported program format");
+        }
+      }
       // push the scope
       d_state.pushScope();
       std::vector<Expr> vars = d_eparser.parseAndBindSortedVarList();

--- a/user_manual.md
+++ b/user_manual.md
@@ -945,15 +945,28 @@ Otherwise, the term `(alf.as t (-> T1 ... Tn T))` is unevaluated.
 
 # Declaring Proof Rules
 
-The ALF language supports a command `declare-rule` for defining proof rules. Its syntax is given by:
+The generic syntax for a `declare-rule` command accepted by `alfc` is:
 ```
-(declare-rule <symbol> (<typed-param>*) <assumption>? <premises>? <arguments>? <reqs>? :conclusion <term>)
+(declare-rule <symbol> <keyword>? <sexpr>*)
+```
+When parsing this command, `alfc` will determine the format of the rule based on the given keyword.
+If the `<keyword>` is not provided, the we assume it has been marked `:alfc`.
+All rules not marked with `:alfc` are not supported by the checker.
+
+Conversely, if the keyword is `:alfc`, then the syntax that follows is more specifically specified below,
+and is used for defining proof rules in the format expected by the ALF checker.
+In particular, this syntax is:
+```
+(declare-rule <symbol> :alfc (<typed-param>*) <assumption>? <premises>? <arguments>? <reqs>? :conclusion <term>)
 where
 <assumption>    ::= :assumption <term>
 <premises>      ::= :premises (<term>*) | :premise-list <term> <term>
 <arguments>     ::= :args (<term>*)
 <reqs>          ::= :requires ((<term> <term>)*)
 ```
+
+After declaring the symbol,
+if the `<keyword>` is not provided, alfc will assume this
 
 A proof rule begins by defining a list of free parameters, followed by 4 optional fields and a conclusion term.
 These fields include:
@@ -1544,7 +1557,7 @@ Valid inputs to the ALF checker are `<alf-command>*`, where:
     (declare-consts <lit-category> <type>) |
     (declare-parameterized-const <symbol> (<typed-param>*) <type> <attr>*) |
     (declare-oracle-fun <symbol> (<type>*) <type> <symbol>) |
-    (declare-rule <symbol> (<typed-param>*) <assumption>? <premises>? <arguments>? <reqs>? :conclusion <term>) |
+    (declare-rule <symbol> <keyword>? <sexpr>*) |
     (declare-type <symbol> (<type>*)) |
     (define <symbol> (<typed-param>*) <term>) |
     (define-type <symbol> (<type>*) <type>) |

--- a/user_manual.md
+++ b/user_manual.md
@@ -963,9 +963,6 @@ where
 <reqs>          ::= :requires ((<term> <term>)*)
 ```
 
-After declaring the symbol,
-if the `<keyword>` is not provided, alfc will assume this
-
 A proof rule begins by defining a list of free parameters, followed by 4 optional fields and a conclusion term.
 These fields include:
 - `<premises>`, denoting the premise patterns of the proof rule. This is either a list of formulas (via `:premises`) or the specification of list of premises via (via `:premise-list`), which will be described in detail later.
@@ -1564,13 +1561,13 @@ Valid inputs to the ALF checker are `<alf-command>*`, where:
     (declare-consts <lit-category> <type>) |
     (declare-parameterized-const <symbol> (<typed-param>*) <type> <attr>*) |
     (declare-oracle-fun <symbol> (<type>*) <type> <symbol>) |
-    (declare-rule <symbol> <keyword>? <sexpr>*) |
-    (declare-rule <symbol> :alfc (<typed-param>*) <assumption>? <premises>? <arguments>? <reqs>? :conclusion <term>) |
+    (declare-rule <symbol> <keyword> <sexpr>*) |
+    (declare-rule <symbol> (<typed-param>*) <assumption>? <premises>? <arguments>? <reqs>? :conclusion <term>) |
     (declare-type <symbol> (<type>*)) |
     (define <symbol> (<typed-param>*) <term>) |
     (define-type <symbol> (<type>*) <type>) |
     (include <string>) |
-    (program <symbol> <keyword>? <sexpr>*) |
+    (program <symbol> <keyword> <sexpr>*) |
     (program <symbol> (<typed-param>*) (<type>*) <type> ((<term> <term>)+)) |
     (reference <string> <symbol>?) |
     (step <symbol> <term>? :rule <symbol> <simple-premises>? <arguments>?) |

--- a/user_manual.md
+++ b/user_manual.md
@@ -951,7 +951,7 @@ The generic syntax for a `declare-rule` command accepted by `alfc` is:
 ```
 When parsing this command, `alfc` will determine the format of the expected arguments based on the given keyword.
 If the `<keyword>` is not provided, the we assume it has been marked `:alfc`.
-All rules not marked with `:alfc` are not supported by the checker and will be ignored.
+All rules not marked with `:alfc` are not supported by the checker are unsupported and will cause the checker to terminate.
 
 If the keyword is `:alfc`, then the expected syntax that follows is given below:
 ```
@@ -1119,7 +1119,7 @@ Similar to `declare-rule`, the ALF checker supports an extensible syntax for pro
 ```
 When parsing this command, `alfc` will determine the format of the expected arguments based on the given keyword.
 If the `<keyword>` is not provided, the we assume it has been marked `:alfc`.
-All programs not marked with `:alfc` are not supported by the checker and will be ignored.
+All programs not marked with `:alfc` are not supported by the checker are unsupported and will cause the checker to terminate.
 
 If the keyword is `:alfc`, then the expected syntax that follows is given below, and is used for defining recursive programs.
 In particular, in the ALF checker, a program is an ordered lists of rewrite rules.

--- a/user_manual.md
+++ b/user_manual.md
@@ -949,13 +949,11 @@ The generic syntax for a `declare-rule` command accepted by `alfc` is:
 ```
 (declare-rule <symbol> <keyword>? <sexpr>*)
 ```
-When parsing this command, `alfc` will determine the format of the rule based on the given keyword.
+When parsing this command, `alfc` will determine the format of the expected arguments based on the given keyword.
 If the `<keyword>` is not provided, the we assume it has been marked `:alfc`.
-All rules not marked with `:alfc` are not supported by the checker.
+All rules not marked with `:alfc` are not supported by the checker and will be ignored.
 
-Conversely, if the keyword is `:alfc`, then the syntax that follows is more specifically specified below,
-and is used for defining proof rules in the format expected by the ALF checker.
-In particular, this syntax is:
+If the keyword is `:alfc`, then the expected syntax that follows is given below:
 ```
 (declare-rule <symbol> :alfc (<typed-param>*) <assumption>? <premises>? <arguments>? <reqs>? :conclusion <term>)
 where
@@ -1118,10 +1116,19 @@ Locally assumptions can be arbitrarily nested, for example the above can be exte
 
 # Side Conditions
 
-The ALF language supports a command for defining ordered lists of rewrite rules that can be seen as computational side conditions.
+Similar to `declare-rule`, the ALF checker supports an extensible syntax for programs whose generic syntax is given by:
+```
+(program <symbol> <keyword>? <sexpr>*)
+```
+When parsing this command, `alfc` will determine the format of the expected arguments based on the given keyword.
+If the `<keyword>` is not provided, the we assume it has been marked `:alfc`.
+All programs not marked with `:alfc` are not supported by the checker and will be ignored.
+
+If the keyword is `:alfc`, then the expected syntax that follows is given below, and is used for defining recursive programs.
+In particular, in the ALF checker, a program is an ordered lists of rewrite rules.
 The syntax for this command is as follows.
 ```
-(program <symbol> (<typed-param>*) (<type>*) <type> ((<term> <term>)+))
+(program <symbol> :alfc (<typed-param>*) (<type>*) <type> ((<term> <term>)+))
 ```
 This command declares a program named `<symbol>`.
 The provided type parameters are implicit and are used to define its type signature and body.
@@ -1558,10 +1565,12 @@ Valid inputs to the ALF checker are `<alf-command>*`, where:
     (declare-parameterized-const <symbol> (<typed-param>*) <type> <attr>*) |
     (declare-oracle-fun <symbol> (<type>*) <type> <symbol>) |
     (declare-rule <symbol> <keyword>? <sexpr>*) |
+    (declare-rule <symbol> :alfc (<typed-param>*) <assumption>? <premises>? <arguments>? <reqs>? :conclusion <term>) |
     (declare-type <symbol> (<type>*)) |
     (define <symbol> (<typed-param>*) <term>) |
     (define-type <symbol> (<type>*) <type>) |
     (include <string>) |
+    (program <symbol> <keyword>? <sexpr>*) |
     (program <symbol> (<typed-param>*) (<type>*) <type> ((<term> <term>)+)) |
     (reference <string> <symbol>?) |
     (step <symbol> <term>? :rule <symbol> <simple-premises>? <arguments>?) |


### PR DESCRIPTION
This is required to support further syntax differences in a backwards compatible manner.

Currently `program` and `declare-rule` are the two commands which I consider whose syntax should not be considered authoritative in our input format, although perhaps more should be considered.