### PR TITLE
Remove strict parse option

### DIFF
--- a/src/cmd_parser.cpp
+++ b/src/cmd_parser.cpp
@@ -28,24 +28,19 @@ CmdParser::CmdParser(Lexer& lex,
     : d_lex(lex), d_state(state), d_eparser(eparser), d_isReference(isReference), d_isFinished(false)
 {
   // initialize the command tokens
-  bool strictParsing = d_state.getOptions().d_strictParsing;
   // commands supported in both inputs and proofs
+  d_table["declare-codatatype"] = Token::DECLARE_CODATATYPE;    // TODO: remove
+  d_table["declare-codatatypes"] = Token::DECLARE_CODATATYPES;  // TODO: remove
   d_table["declare-const"] = Token::DECLARE_CONST;
   d_table["declare-datatype"] = Token::DECLARE_DATATYPE;
   d_table["declare-datatypes"] = Token::DECLARE_DATATYPES;
+  d_table["declare-oracle-fun"] = Token::DECLARE_ORACLE_FUN;
+  d_table["declare-parameterized-const"] = Token::DECLARE_PARAMETERIZED_CONST;
   d_table["echo"] = Token::ECHO;
   d_table["exit"] = Token::EXIT;
   d_table["pop"] = Token::POP;
   d_table["push"] = Token::PUSH;
   d_table["reset"] = Token::RESET;
-  // non-standard commands supported in inputs and proofs
-  if (!strictParsing)
-  {
-    d_table["declare-codatatype"] = Token::DECLARE_CODATATYPE;
-    d_table["declare-codatatypes"] = Token::DECLARE_CODATATYPES;
-    d_table["declare-parameterized-const"] = Token::DECLARE_PARAMETERIZED_CONST;
-    d_table["declare-oracle-fun"] = Token::DECLARE_ORACLE_FUN;
-  }
 
   if (d_isReference)
   {
@@ -64,23 +59,18 @@ CmdParser::CmdParser(Lexer& lex,
   }
   else
   {
-    // not defined in smt 2.6, or not supported
+    d_table["assume"] = Token::ASSUME;
+    d_table["assume-push"] = Token::ASSUME_PUSH;
+    d_table["declare-consts"] = Token::DECLARE_CONSTS;
+    d_table["declare-rule"] = Token::DECLARE_RULE;
     d_table["declare-type"] = Token::DECLARE_TYPE;
+    d_table["define"] = Token::DEFINE;
     d_table["define-type"] = Token::DEFINE_TYPE;
-    // not defined in smt 2.6 or in smt 3.0 proposal
-    if (!strictParsing)
-    {
-      d_table["assume"] = Token::ASSUME;
-      d_table["assume-push"] = Token::ASSUME_PUSH;
-      d_table["declare-consts"] = Token::DECLARE_CONSTS;
-      d_table["declare-rule"] = Token::DECLARE_RULE;
-      d_table["define"] = Token::DEFINE;
-      d_table["include"] = Token::INCLUDE;
-      d_table["program"] = Token::PROGRAM;
-      d_table["reference"] = Token::REFERENCE;
-      d_table["step"] = Token::STEP;
-      d_table["step-pop"] = Token::STEP_POP;
-    }
+    d_table["include"] = Token::INCLUDE;
+    d_table["program"] = Token::PROGRAM;
+    d_table["reference"] = Token::REFERENCE;
+    d_table["step"] = Token::STEP;
+    d_table["step-pop"] = Token::STEP_POP;
   }
   
   d_statsEnabled = d_state.getOptions().d_stats;

--- a/src/cmd_parser.cpp
+++ b/src/cmd_parser.cpp
@@ -29,17 +29,15 @@ CmdParser::CmdParser(Lexer& lex,
 {
   // initialize the command tokens
   // commands supported in both inputs and proofs
-  d_table["declare-codatatype"] = Token::DECLARE_CODATATYPE;    // TODO: remove
-  d_table["declare-codatatypes"] = Token::DECLARE_CODATATYPES;  // TODO: remove
+  d_table["declare-codatatype"] = Token::DECLARE_CODATATYPE;    // undocumented, TODO: remove
+  d_table["declare-codatatypes"] = Token::DECLARE_CODATATYPES;  // undocumented, TODO: remove
   d_table["declare-const"] = Token::DECLARE_CONST;
   d_table["declare-datatype"] = Token::DECLARE_DATATYPE;
   d_table["declare-datatypes"] = Token::DECLARE_DATATYPES;
-  d_table["declare-oracle-fun"] = Token::DECLARE_ORACLE_FUN;
-  d_table["declare-parameterized-const"] = Token::DECLARE_PARAMETERIZED_CONST;
   d_table["echo"] = Token::ECHO;
   d_table["exit"] = Token::EXIT;
-  d_table["pop"] = Token::POP;
-  d_table["push"] = Token::PUSH;
+  d_table["pop"] = Token::POP;    // undocumented
+  d_table["push"] = Token::PUSH;  // undocumented
   d_table["reset"] = Token::RESET;
 
   if (d_isReference)
@@ -62,6 +60,8 @@ CmdParser::CmdParser(Lexer& lex,
     d_table["assume"] = Token::ASSUME;
     d_table["assume-push"] = Token::ASSUME_PUSH;
     d_table["declare-consts"] = Token::DECLARE_CONSTS;
+    d_table["declare-oracle-fun"] = Token::DECLARE_ORACLE_FUN;
+    d_table["declare-parameterized-const"] = Token::DECLARE_PARAMETERIZED_CONST;
     d_table["declare-rule"] = Token::DECLARE_RULE;
     d_table["declare-type"] = Token::DECLARE_TYPE;
     d_table["define"] = Token::DEFINE;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,10 +52,6 @@ int main( int argc, char* argv[] )
       opts.d_stats = true;
       opts.d_statsCompact = true;
     }
-    else if (arg=="--strict-parsing")
-    {
-      opts.d_strictParsing = true;
-    }
     else if (arg=="--no-rule-sym-table")
     {
       opts.d_ruleSymTable = false;
@@ -81,7 +77,6 @@ int main( int argc, char* argv[] )
       out << "      --show-config: displays the build information for this binary." << std::endl;
       out << "            --stats: enables detailed statistics." << std::endl;
       out << "    --stats-compact: print statistics in a compact format." << std::endl;
-      out << "   --strict-parsing: only accept commands in the SMT-LIB version 3.0 proposal. No proofs are supported when this is enabled." << std::endl;
       out << "           -t <tag>: enables the given trace tag (requires debug build)." << std::endl;
       out << "                 -v: verbose mode, enable all standard trace messages (requires debug build)." << std::endl;
       std::cout << out.str();

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -26,7 +26,6 @@ Options::Options()
   d_ruleSymTable = true;
   d_normalizeDecimal = true;
   d_normalizeHexadecimal = true;
-  d_strictParsing = false;
   d_binderFresh = false;
 }
 

--- a/src/state.h
+++ b/src/state.h
@@ -38,8 +38,6 @@ class Options
   bool d_ruleSymTable;
   bool d_normalizeDecimal;
   bool d_normalizeHexadecimal;
-  /** Whether we only accept commands in the SMT-LIB version 3 proposal */
-  bool d_strictParsing;
   /** Binders generate fresh variables in proof and reference files */
   bool d_binderFresh;
 };

--- a/user_manual.md
+++ b/user_manual.md
@@ -1554,7 +1554,6 @@ The ALF command line interface can be invoked by `alfc <option>* <file>` where `
 - `--show-config`: displays the build information for the given binary.
 - `--stats`: enables detailed statistics.
 - `--stats-compact`: print statistics in a compact format.
-- `--strict-parsing`: only accept commands in the SMT-LIB version 3.0 proposal. No proofs are supported when this option is enabled.
 - `-t <tag>`: enables the given trace tag (for debugging).
 - `-v`: verbose mode, enable all standard trace messages.
 


### PR DESCRIPTION
We no longer seek to accept smt3 verbatim.

Also corrects some misclassified commands in the parser.