### PR TITLE
Update policy for disambiguating overloads

### DIFF
--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1394,7 +1394,6 @@ Expr State::getOverloadInternal(const std::vector<Expr>& overloads,
   {
     vchildren.push_back(c.getValue());
   }
-  Expr ret;
   // try overloads in order until one is found
   for (const Expr& o : overloads)
   {
@@ -1404,16 +1403,12 @@ Expr State::getOverloadInternal(const std::vector<Expr>& overloads,
     // if term is well-formed, and matches the return type if it exists
     if (!t.isNull() && (retType==nullptr || retType==t.getValue()))
     {
-      if (!ret.isNull())
-      {
-        Warning() << "State::getOverloadInternal ambiguous application of " << ret << std::endl;
-        continue;
-      }
-      ret = o;
+      // return the operator, do not check the remainder
+      return o;
     }
   }
   // otherwise, none found, return null
-  return ret;
+  return d_null;
 }
 
 }  // namespace alfc

--- a/src/state.h
+++ b/src/state.h
@@ -229,8 +229,7 @@ class State
    * application.
    * @return If possible, one of the elements of overloads that meets
    * the above requirements. If multiple are possible, we return the
-   * first and give warnings for those beyond the first. If none are
-   * possible, we return the null expression.
+   * first only. If none are possible, we return the null expression.
    */
   Expr getOverloadInternal(const std::vector<Expr>& overloads,
                            const std::vector<Expr>& children,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -123,6 +123,7 @@ set(alfc_test_file_list
     overloading-arith.smt3
     overloading-binder.smt3
     sorry.smt3
+    disamb-arith.smt3
 )
 
 macro(alfc_test file)

--- a/tests/disamb-arith.smt3
+++ b/tests/disamb-arith.smt3
@@ -1,0 +1,8 @@
+(declare-type Int ())
+(declare-const - (-> Int Int))
+(declare-const - (-> Int Int Int))
+
+(declare-const = (-> (! Type :var A :implicit) A A Bool))
+(declare-consts <numeral> Int)
+
+(assume @p0 (= (- 1) -1))

--- a/user_manual.md
+++ b/user_manual.md
@@ -951,7 +951,8 @@ In particular, if a symbol is overloaded, the ALF checker will use the first sym
 For example, ssuming standard definitions of SMT-LIB literal values,
 `(- 1)` uses the first, `(- 0 1)` uses the second, and `(- 0.0 1.0)` uses the third.
 If a symbol is unapplied, then the ALF checker will interpret it as the first declared term for that symbol.
-A warning is printed if multiple symbols are applicable.
+
+> The ALF checker will not throw a warning if multiple variants are applicable, and instead use the first one. This behavior permits the user to order the declarations in the order of their precedence. For example, the SMT-LIB operator for unary negation should be declared *before* the declaration for subtraction. If this were done in the opposite order, then (- t) would be interpreted as the partial application of subtraction to the term t.
 
 Furthermore, the ALF checker supports an operator `alf.as` for disambiguation whose syntax is `(alf.as <term> <type>)`.
 A term of the form `(alf.as t (-> T1 ... Tn T))` evaluates to `t` only if `(t k1 ... kn)` has type `T` where `k1 ... kn` are variables of type `T1 ... Tn`.

--- a/user_manual.md
+++ b/user_manual.md
@@ -952,7 +952,7 @@ For example, ssuming standard definitions of SMT-LIB literal values,
 `(- 1)` uses the first, `(- 0 1)` uses the second, and `(- 0.0 1.0)` uses the third.
 If a symbol is unapplied, then the ALF checker will interpret it as the first declared term for that symbol.
 
-> The ALF checker will not throw a warning if multiple variants are applicable, and instead use the first one. This behavior permits the user to order the declarations in the order of their precedence. For example, the SMT-LIB operator for unary negation should be declared *before* the declaration for subtraction. If this were done in the opposite order, then (- t) would be interpreted as the partial application of subtraction to the term t.
+> When multiple variants are possible, the ALF checker will use the first one and will *not* throw a warning. This behavior permits the user to order the declarations in the order of their precedence. For example, the SMT-LIB operator for unary negation should be declared *before* the declaration for subtraction. If this were done in the opposite order, then (- t) would be interpreted as the partial application of subtraction to the term t.
 
 Furthermore, the ALF checker supports an operator `alf.as` for disambiguation whose syntax is `(alf.as <term> <type>)`.
 A term of the form `(alf.as t (-> T1 ... Tn T))` evaluates to `t` only if `(t k1 ... kn)` has type `T` where `k1 ... kn` are variables of type `T1 ... Tn`.


### PR DESCRIPTION
The order of declarations from the user is now interpreted as the precedence order.

This means the user needs to declare e.g. unary `-` before binary `-` to achieve the expected result.

I open to making this policy e.g. configurable by an option later if needed.