### PR TITLE
Reverse policy for overloads

### DIFF
--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1395,16 +1395,18 @@ Expr State::getOverloadInternal(const std::vector<Expr>& overloads,
     vchildren.push_back(c.getValue());
   }
   // try overloads in order until one is found
-  for (const Expr& o : overloads)
+  for (size_t i=0, noverloads = overloads.size(); i<noverloads; i++)
   {
-    vchildren[0] = o.getValue();
+    // search in reverse order, i.e. the last bound symbol takes precendence
+    size_t ii = (noverloads-1)-i;
+    vchildren[0] = overloads[ii].getValue();
     Expr x = Expr(vchildren.size()>2 ? mkApplyInternal(vchildren) : mkExprInternal(Kind::APPLY, vchildren));
     Expr t = d_tc.getType(x);
     // if term is well-formed, and matches the return type if it exists
     if (!t.isNull() && (retType==nullptr || retType==t.getValue()))
     {
       // return the operator, do not check the remainder
-      return o;
+      return overloads[ii];
     }
   }
   // otherwise, none found, return null

--- a/tests/arity-overload.smt3
+++ b/tests/arity-overload.smt3
@@ -1,6 +1,7 @@
 (declare-type Int ())
-(declare-const - (-> Int Int))
 (declare-const - (-> Int Int Int))
+; bound after above
+(declare-const - (-> Int Int))
 
 (declare-const = (-> (! Type :var T :implicit) T T Bool))
 (declare-const a Int)

--- a/tests/disamb-arith.smt3
+++ b/tests/disamb-arith.smt3
@@ -1,6 +1,7 @@
 (declare-type Int ())
-(declare-const - (-> Int Int))
 (declare-const - (-> Int Int Int))
+; bound after above
+(declare-const - (-> Int Int))
 
 (declare-const = (-> (! Type :var A :implicit) A A Bool))
 (declare-consts <numeral> Int)


### PR DESCRIPTION
It is much clearer to view overloading as an instance of shadowing where the last bound term takes precendence.